### PR TITLE
Adding key and port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A single context manager (cd) is provided for running commands in a particular d
 
 ### Module-Use Example:
 ```
-from yarn.api import cd, env, run
+from yarn.api import env, cd, run
 
 
 env.host_string = '192.168.1.2'
@@ -41,7 +41,7 @@ And it would have worked the same.
 
 ### Yarnfile Example:
 ```
-from yarn.api import cd, run
+from yarn.api import env, cd, run
 
 
 def test():
@@ -80,7 +80,7 @@ The 'env' namespace contains several variables which can be set by the developer
 ### Using a RSA key to authenticate
 
 ```
-from yarn.api import cd, run
+from yarn.api import env, cd, run
 
 env.host_string = "192.168.1.2"
 env.host_port = 22

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ A single context manager (cd) is provided for running commands in a particular d
 
 ### Module-Use Example:
 ```
-from yarn.api import cd
-from yarn.api import env
-from yarn.api import run
+from yarn.api import cd, env, run
 
 
 env.host_string = '192.168.1.2'
@@ -43,9 +41,7 @@ And it would have worked the same.
 
 ### Yarnfile Example:
 ```
-from yarn.api import cd
-from yarn.api import env
-from yarn.api import run
+from yarn.api import cd, run
 
 
 def test():

--- a/README.md
+++ b/README.md
@@ -73,3 +73,26 @@ The 'env' namespace contains several variables which can be set by the developer
 * host_string - (String) This is the host to which the system is going to connect.  DNS names (if dns is working) can be used here.
 * user - (String) This is the username to use when connecting to the host.
 * password - (String) This is the password for the user.  If you have already copied an SSH key to the remote host, this is not required.
+* port - (Integer)
+
+### Using a RSA key to authenticate
+
+```
+from yarn.api import cd, run
+
+env.host_string = "192.168.1.2"
+env.host_port = 22
+env.user = "root"
+env.key = "/home/user/.ssh/id_rsa"
+env.passphrase = "example_passphrase"
+
+print(run("uname"))
+
+```
+
+Output:
+
+```
+[2015-10-26 12:27:00,865] DEBUG - run: RUNNING 'uname' on '192.168.1.2'
+Linux
+```

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ This would output the same as the previous module example.  Of note, is that the
 ### The Environment
 The 'env' namespace contains several variables which can be set by the developer.
 * host_string - (String) This is the host to which the system is going to connect.  DNS names (if dns is working) can be used here.
+* host_port - (Integer) This is the port on the remove machine accepting incoming SSh connections.
 * user - (String) This is the username to use when connecting to the host.
 * password - (String) This is the password for the user.  If you have already copied an SSH key to the remote host, this is not required.
-* port - (Integer)
+* key - (String) Path to RSA key file to use to authenticate with remote host.
+* passphrase - (String) Password to use the key file.
 
 ### Using a RSA key to authenticate
 

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import unittest
+from yarn.api import env
+
+
+class TestEnv(unittest.TestCase):
+
+    def test_env_port(self):
+        env.host_port = 66
+        assert env._port == 66 and env.host_port == 66
+
+    def test_env_port_non_int(self):
+        def set_port_non_int():
+            env.host_port = "test"
+        self.assertRaises(AttributeError, set_port_non_int)
+
+    def test_env_port_bad_int(self):
+        def set_port_bad_int():
+            env.host_port = 111111
+        self.assertRaises(AttributeError, set_port_bad_int)

--- a/yarn/yarn.py
+++ b/yarn/yarn.py
@@ -7,6 +7,7 @@ import argparse
 import importlib
 from yarn.api import env
 
+
 def parse_host_list(host_list):
     return host_list.split(",")
 
@@ -34,4 +35,4 @@ if __name__ == '__main__':
         except AttributeError:
             print("No command called '{}' in the yarnfile".format(",".join(args.commands)))
 
-    
+


### PR DESCRIPTION
- Added RSA key authentication
- Added API ability to switch SSH port
- Added test file for Environment tests including three for the new port switching
- Updated Readme with example and environment documentation
- Updated default user in API to current user (to match console script) 
- Updated default host_string to be an empty string, not  None
- Updated deprecated use of "logger.warn" 
- Did NOT update console script arguments for new configuration
- Did NOT add unit tests for key usage (as it would require key file and example system) 
